### PR TITLE
Fix issues with despawned bots

### DIFF
--- a/BotInfo.cs
+++ b/BotInfo.cs
@@ -186,7 +186,10 @@ namespace DrakiaXYZ.BotDebug
                 var goalEnemy = actorDataStruct.PlayerOwner.AIData.BotOwner.Memory.GoalEnemy;
                 if (goalEnemy?.Person?.IsAI == true)
                 {
-                    stringBuilder.AppendLabeledValue("GoalEnemy", $"{goalEnemy?.Person?.AIData?.BotOwner?.name}", Color.white, Color.white, true);
+                    if (goalEnemy?.Person?.AIData?.BotOwner != null)
+                    {
+                        stringBuilder.AppendLabeledValue("GoalEnemy", $"{goalEnemy?.Person?.AIData?.BotOwner?.name}", Color.white, Color.white, true);
+                    }
                 }
                 else
                 {

--- a/Components/BotDebugComponent.cs
+++ b/Components/BotDebugComponent.cs
@@ -142,6 +142,11 @@ namespace DrakiaXYZ.BotDebug.Components
             {
                 var botData = bot.Value.Data;
                 if (!botData.InitedBotData) continue;
+                if (botData.PlayerOwner?.AIData?.BotOwner == null)
+                {
+                    deadList.Add(bot.Key);
+                    continue;
+                }
 
                 // If the bot hasn't been updated in over 3 seconds, it's dead Jim, remove it
                 if (Time.time - bot.Value.LastUpdate >= 3f)


### PR DESCRIPTION
- If a bot doesn't have a BotOwner, consider it dead/despawned
- Verify that the GoalEnemy BotOwner isn't null before trying to access it